### PR TITLE
feat: refactor URLInputBox for static urls

### DIFF
--- a/src/components/URLInputBox.tsx
+++ b/src/components/URLInputBox.tsx
@@ -16,8 +16,6 @@ const URLInputBox: React.FC<URLInputBoxProps> = ({
   isStatic = false,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [buttonText, setButtonText] = useState<string>("View"); // Button text state
-  const [isCopied, setIsCopied] = useState(false); // State to track if the URL is copied
   const [completeUrl, setCompleteUrl] = useState(endpoint || ""); // State to store the complete URL
 
   const handleDivClick = () => {
@@ -32,29 +30,6 @@ const URLInputBox: React.FC<URLInputBoxProps> = ({
       ? `${endpoint.replace(/\/$/, "")}/${inputValue}`
       : inputValue;
     setCompleteUrl(newUrl);
-  };
-
-  const handleCopyUrl = () => {
-    const inputValue = inputRef.current?.value || "";
-
-    // Concatenate the URL and input value
-    const fullUrl = `${endpoint}${inputValue}`;
-
-    // Copy to clipboard
-    navigator.clipboard
-      .writeText(fullUrl)
-      .then(() => {
-        setButtonText("Copied!");
-        setIsCopied(true);
-
-        setTimeout(() => {
-          setButtonText("Copy");
-          setIsCopied(false);
-        }, 2000);
-      })
-      .catch((err) => {
-        console.error("Failed to copy:", err);
-      });
   };
 
   return (
@@ -77,14 +52,12 @@ const URLInputBox: React.FC<URLInputBoxProps> = ({
         </div>
 
         <a
-          className={`bg-brand-neutral-900 text-white rounded-md px-6 py-2 absolute top-2 right-2 flex items-center gap-1 ${
-            isCopied ? "bg-blue-500" : ""
-          }`}
+          className={`bg-brand-neutral-900 text-white rounded-md px-6 py-2 absolute top-2 right-2 flex items-center gap-1`}
           href={completeUrl}
           target="_blank"
           rel="noopener"
         >
-          {buttonText}
+          View
           <ExternalIcon />
         </a>
       </div>

--- a/src/components/URLInputBox.tsx
+++ b/src/components/URLInputBox.tsx
@@ -1,25 +1,37 @@
 "use client";
+import ExternalIcon from "@/image/icons/icon-external.svg";
 import { useRef, useState } from "react";
 
 interface URLInputBoxProps {
   endpoint?: string;
   placeholder?: string;
   helpText?: string;
+  isStatic?: boolean;
 }
 
 const URLInputBox: React.FC<URLInputBoxProps> = ({
   endpoint,
   placeholder,
   helpText,
+  isStatic = false,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [buttonText, setButtonText] = useState<string>("Copy"); // Button text state
+  const [buttonText, setButtonText] = useState<string>("View"); // Button text state
   const [isCopied, setIsCopied] = useState(false); // State to track if the URL is copied
+  const [completeUrl, setCompleteUrl] = useState(endpoint || ""); // State to store the complete URL
 
   const handleDivClick = () => {
     if (inputRef.current) {
       inputRef.current.focus(); // Focus the input
     }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    const newUrl = endpoint
+      ? `${endpoint.replace(/\/$/, "")}/${inputValue}`
+      : inputValue;
+    setCompleteUrl(newUrl);
   };
 
   const handleCopyUrl = () => {
@@ -53,22 +65,28 @@ const URLInputBox: React.FC<URLInputBoxProps> = ({
       >
         <div className="flex text-brand-neutral-600 w-full">
           <p className="shrink-0">{endpoint || ""}</p>
-          <input
-            ref={inputRef}
-            type="text"
-            placeholder={placeholder}
-            className="focus:outline-none w-full"
-          />
+          {!isStatic && (
+            <input
+              ref={inputRef}
+              type="text"
+              placeholder={placeholder}
+              className="focus:outline-none w-full"
+              onChange={handleInputChange}
+            />
+          )}
         </div>
 
-        <button
-          className={`bg-brand-neutral-900 text-white rounded-md px-6 py-2 absolute top-2 right-2 ${
+        <a
+          className={`bg-brand-neutral-900 text-white rounded-md px-6 py-2 absolute top-2 right-2 flex items-center gap-1 ${
             isCopied ? "bg-blue-500" : ""
           }`}
-          onClick={handleCopyUrl}
+          href={completeUrl}
+          target="_blank"
+          rel="noopener"
         >
           {buttonText}
-        </button>
+          <ExternalIcon />
+        </a>
       </div>
       {helpText && (
         <small className="mt-2 text-sm font-normal">{helpText}</small>

--- a/src/pages/use-cases/git-user.mdx
+++ b/src/pages/use-cases/git-user.mdx
@@ -20,7 +20,7 @@ In addition, the first backend only takes a few properties from the response, an
 The second backend does not return an object, but an array, so we tell KrakenD that this is a collection of elements.
 
 Write an existing GitHub username below, and open the link in the browser or cURL:
-<URLInputBox endpoint="http://localhost:8080/git/" placeholder="username" isStatic />
+<URLInputBox endpoint="http://localhost:8080/git/" placeholder="username" />
 
 
 export default function MDXPage({ children }) {

--- a/src/pages/use-cases/git-user.mdx
+++ b/src/pages/use-cases/git-user.mdx
@@ -1,5 +1,5 @@
 import MdxLayout from '@/components/MdxLayout';
-import URLInputBox from '@/components/URLInputBox'
+import URLInputBox from '@/components/URLInputBox';
 
 ## Endpoint
 ```http
@@ -20,7 +20,7 @@ In addition, the first backend only takes a few properties from the response, an
 The second backend does not return an object, but an array, so we tell KrakenD that this is a collection of elements.
 
 Write an existing GitHub username below, and open the link in the browser or cURL:
-<URLInputBox endpoint="http://localhost:8080/git/" placeholder="username" />
+<URLInputBox endpoint="http://localhost:8080/git/" placeholder="username" isStatic />
 
 
 export default function MDXPage({ children }) {


### PR DESCRIPTION
This pull request includes significant updates to the `URLInputBox` component in the `src/components/URLInputBox.tsx` file, focusing on improving the component's functionality and user experience. Additionally, a minor import formatting change was made in the `src/pages/use-cases/git-user.mdx` file.

### Updates to `URLInputBox` component:

* Added a new optional `isStatic` prop to the `URLInputBox` component to enable static URL box. 
* Replaced the old copy-to-clipboard functionality with a View button. IMO this will be quicker for users to use, but let me know if you'd like to revert back to the original copy functionality.

<img width="631" alt="Screenshot 2025-01-16 at 12 07 59 PM" src="https://github.com/user-attachments/assets/08e98538-cc58-4058-a757-841c8af547f4" />
